### PR TITLE
Fix footer docs link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,7 @@
         <div class="footer-horizontal-rule"></div>
         <ul class="footer-nav-list">
           <li><span class="rsaquo">&rsaquo;</span><a href="/about">About</a></li>
-          <li><span class="rsaquo">&rsaquo;</span><a href="http://dat-data.readthedocs.org">Docs</a></li>
+          <li><span class="rsaquo">&rsaquo;</span><a href="https://github.com/datproject/docs">Docs</a></li>
         </ul>
       </div>
       <div class="col-md-2 col-xs-6">

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
           <li><a href="/about">About</a></li>
           <li><a href="/blog">Blog</a></li>
           <li><a href="/team">Team</a></li>
-          <li><a href="https://github.com/datproject/docs">Docs</a></li>
+          <li><a href="http://docs.dat-data.com">Docs</a></li>
         </ul>
           <a href="https://github.com/maxogden/dat" class="hidden-mobile" target="_blank">
             <div class="button"><span class="octocat"></span>View on GitHub</div>
@@ -46,7 +46,7 @@
         <div class="footer-horizontal-rule"></div>
         <ul class="footer-nav-list">
           <li><span class="rsaquo">&rsaquo;</span><a href="/about">About</a></li>
-          <li><span class="rsaquo">&rsaquo;</span><a href="https://github.com/datproject/docs">Docs</a></li>
+          <li><span class="rsaquo">&rsaquo;</span><a href="http://docs.dat-data.com">Docs</a></li>
         </ul>
       </div>
       <div class="col-md-2 col-xs-6">


### PR DESCRIPTION
The header "Docs" link points to GitHub, but the footer "Docs" link still points to ReadTheDocs, which now responds 404.